### PR TITLE
Update Log.cs

### DIFF
--- a/OverParse/Log.cs
+++ b/OverParse/Log.cs
@@ -257,7 +257,7 @@ namespace OverParse
                 int elapsed = newTimestamp - startTimestamp;
                 TimeSpan timespan = TimeSpan.FromSeconds(elapsed);
                 string timer = timespan.ToString(@"mm\:ss");
-                string log = DateTime.Now.ToString("U") + " | " + timer + Environment.NewLine;
+                string log = DateTime.Now.ToString("F") + " | " + timer + Environment.NewLine;
 
                 log += Environment.NewLine;
 


### PR DESCRIPTION
The "U" and "F" formats both yield the same formatted time, but "U" converts the time to UTC.
Switched to "F" to make sure the time is in the correct timezone
